### PR TITLE
Updated Dockerfile for external configuration.

### DIFF
--- a/fcrepo/Dockerfile
+++ b/fcrepo/Dockerfile
@@ -3,7 +3,12 @@ FROM jetty:9.4.6
 ENV FCREPO_HOME=/var/lib/jetty/fedora-data \
     FCREPO_NAME=fcrepo \
     FCREPO_VERSION=4.7.4 \
-    FCREPO_WAR=/var/lib/jetty/webapps/fcrepo.war
+    FCREPO_WAR=/var/lib/jetty/webapps/fcrepo.war \
+		FCREPO_ETC=/etc/fcrepo
+
+ENV	FCREPO_MODESHAPE_CONFIGURATION=file://${FCREPO_ETC}/repository.json
+ENV	FCREPO_AUTH_WEBAC_AUTHORIZATION=file://${FCREPO_ETC}/root-authorization.ttl
+ENV FCREPO_ACTIVEMQ_CONFIGURATION=file://${FCREPO_ETC}/activemq.xml
 
 RUN apt-get update
 RUN apt-get install -y wget unzip
@@ -30,11 +35,17 @@ COPY ./web.xml /var/lib/jetty/webapps/${FCREPO_NAME}/WEB-INF/
 COPY ./jetty-auth-jars/* /var/lib/jetty/lib/ext/
 COPY ./fcrepo.xml /var/lib/jetty/webapps/fcrepo.xml
 
+# Create an external configuration setup
+RUN mkdir -p ${FCREPO_ETC}
+COPY ./etc/fcrepo/* ${FCREPO_ETC}/
+
 RUN mkdir -p ${FCREPO_HOME} && chmod -R a+rw ${FCREPO_HOME}
 VOLUME ["$FCREPO_HOME"]
 
 ENV JAVA_OPTS="-Dfile.encoding=UTF-8 \
     -Dfcrepo.home=${FCREPO_HOME} \
-    -Dfcrepo.modeshape.configuration=classpath:/config/servlet-auth/repository.json" 
+    -Dfcrepo.modeshape.configuration=${FCREPO_MODESHAPE_CONFIGURATION}" \
+    -Dfcrepo.auth.webac.authorization=${FCREPO_AUTH_WEBAC_AUTHORIZATION}" \
+    -Dfcrepo.activemq.configuration=${FCREPO_ACTIVEMQ_CONFIGURATION}"
 
 CMD java $JAVA_OPTS -jar "$JETTY_HOME/start.jar"

--- a/fcrepo/etc/fcrepo/README.md
+++ b/fcrepo/etc/fcrepo/README.md
@@ -1,0 +1,14 @@
+# FCREPO Configuration
+
+Following the advice from Fedora [Configuration Best
+Practices](https://wiki.duraspace.org/display/FEDORA4x/Best+Practices+-+Fedora+Configuration),
+we've moved some files to an external location.  This allows an easier
+modification for users.  This is exposed as /etc/fcrepo/* configuration files.
+
+The default repository.json file is the same as found in
+`classpath:/config/serlet-auth/repository.json` with a modification to include
+extra RDF prefixes that are defined in `namespaces.cnd`
+
+I've also included the other files suggested but the Best Practices, with the
+exception of the config.xml file for the spring framework, which is
+unintelligible for me.

--- a/fcrepo/etc/fcrepo/activemq.xml
+++ b/fcrepo/etc/fcrepo/activemq.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:amq="http://activemq.apache.org/schema/core"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+    http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <context:property-placeholder/>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost">
+
+        <!--
+            For better performances use VM cursor and small memory limit.
+            For more information, see:
+
+            http://activemq.apache.org/message-cursors.html
+
+            Also, if your producer is "hanging", it's probably due to producer flow control.
+            For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+        -->
+
+        <destinationPolicy>
+            <policyMap>
+                <policyEntries>
+                    <policyEntry topic=">" producerFlowControl="true">
+                        <!-- The constantPendingMessageLimitStrategy is used to prevent
+                         slow topic consumers to block producers and affect other consumers
+                         by limiting the number of messages that are retained
+                         For more information, see:
+
+                         http://activemq.apache.org/slow-consumer-handling.html
+
+                    -->
+                        <pendingMessageLimitStrategy>
+                            <constantPendingMessageLimitStrategy limit="1000"/>
+                        </pendingMessageLimitStrategy>
+                    </policyEntry>
+                    <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
+                        <!-- Use VM cursor for better latency
+                       For more information, see:
+
+                       http://activemq.apache.org/message-cursors.html
+
+                  <pendingQueuePolicy>
+                    <vmQueueCursor/>
+                  </pendingQueuePolicy>
+                  -->
+                    </policyEntry>
+                </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${fcrepo.activemq.directory:ActiveMQ/kahadb}"/>
+        </persistenceAdapter>
+
+
+        <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+            If using ActiveMQ embedded - the following limits could safely be used:
+            -->
+
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage limit="20 mb"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="1 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="100 mb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <transportConnector name="openwire"
+                uri="tcp://0.0.0.0:${fcrepo.dynamic.jms.port:61616}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
+            />
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:${fcrepo.dynamic.stomp.port:61613}"/>
+        </transportConnectors>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans"
+                class="org.apache.activemq.hooks.SpringContextHook"/>
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+
+    <import resource="jetty.xml"/>
+    -->
+</beans>

--- a/fcrepo/etc/fcrepo/namespaces.cnd
+++ b/fcrepo/etc/fcrepo/namespaces.cnd
@@ -1,0 +1,13 @@
+<acl = 'http://www.w3.org/ns/auth/acl#'>
+<cc = 'http://creativecommons.org/ns#'>
+<dcterms = 'http://purl.org/dc/terms/'>
+<exif = 'http://www.w3.org/2003/12/exif/ns#'>
+<geo = 'http://www.w3.org/2003/01/geo/wgs84_pos#'>
+<gn = 'http://www.geonames.org/ontology#'>
+<iana = 'http://www.iana.org/assignments/relation/'>
+<ore = 'http://www.openarchives.org/ore/terms/'>
+<owl = 'http://www.w3.org/2002/07/owl#'>
+<prov = 'http://www.w3.org/ns/prov#'>
+<rel = 'http://id.loc.gov/vocabulary/relators/'>
+<schema = 'http://schema.org/'>
+<skos = 'http://www.w3.org/2004/02/skos/core#'>

--- a/fcrepo/etc/fcrepo/repository.json
+++ b/fcrepo/etc/fcrepo/repository.json
@@ -1,0 +1,36 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true,
+        "cacheSize" : 10000
+    },
+    "storage" : {
+        "persistence": {
+            "type": "file",
+            "path" : "${fcrepo.object.directory:target/objects}"
+        },
+        "binaryStorage" : {
+            "type" : "file",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
+            "minimumBinarySizeInBytes" : 4096
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.ServletContainerAuthenticationProvider" }
+        ]
+    },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
+		"node-types" : ["fedora-node-types.cnd", "file:/etc/fcrepo/namespaces.cnd"]
+}

--- a/fcrepo/etc/fcrepo/root-authorization.ttl
+++ b/fcrepo/etc/fcrepo/root-authorization.ttl
@@ -1,0 +1,10 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
+
+<> a acl:Authorization ;
+   rdfs:label "Root Authorization" ;
+   rdfs:comment "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
+   acl:agent foaf:Agent ;
+   acl:accessToClass fedora:Resource .


### PR DESCRIPTION
In order to update fedora, so that we get to see a nice schema: prefix, I needed to move the modeshape.configuration to an external file.

Following the advice from Fedora [Configuration Best
Practices](https://wiki.duraspace.org/display/FEDORA4x/Best+Practices+-+Fedora+Configuration),
we've moved some files to an external location.  This allows an easier
modification for users.  This is exposed as /etc/fcrepo/* configuration files.

