### PR TITLE
COPY cmd w/out ./* is recursive

### DIFF
--- a/services/essync/Dockerfile
+++ b/services/essync/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:8
 
-RUN mkdir -p /service
-COPY ./* /service/
+COPY ./ /service/
 RUN cd /service && npm install 
 
 CMD node service


### PR DESCRIPTION
I'm not sure how that was working, the dockerhub seems broken.  According to docs COPY ./ will be recursive while COPY ./* is not.